### PR TITLE
Exposed functionalities in `FastModularTokenizer`

### DIFF
--- a/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
@@ -1402,7 +1402,7 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
         raise Exception("Not implemented")
 
     @staticmethod
-    def from_file(path: str) -> object:
+    def from_file(path: str) -> "ModularTokenizer":
         """
         Accepts a file or directory, and loads a modular tokenizer stored in that directory
 

--- a/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
@@ -5,7 +5,7 @@ from fusedrug.data.tokenizer.modulartokenizer.modular_tokenizer import (
 )
 from warnings import warn
 from collections import defaultdict
-from typing import Tuple, Optional, Union, Any
+from typing import Tuple, Optional, Union, Any, List
 import os
 import re
 
@@ -285,5 +285,5 @@ class FastModularTokenizer(OpBase):
     def get_tokenizer(self) -> Tokenizer:
         return self._tokenizer
 
-    def add_special_tokens(self, tokens: list[str]) -> int:
+    def add_special_tokens(self, tokens: List[str]) -> int:
         self._tokenizer.add_special_tokens(tokens)

--- a/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
@@ -281,3 +281,9 @@ class FastModularTokenizer(OpBase):
             )
 
         return sample_dict
+
+    def get_tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    def add_special_tokens(self, tokens: list[str]) -> int:
+        self._tokenizer.add_special_tokens(tokens)


### PR DESCRIPTION
Exposed couple of functionalities of `ModularTokenizer` in the op and fixed a minor type hint

#### Motivation:
Add special tokens more nicely in a task DataModule:

```python
self.tokenizer_op.add_special_tokens([DIFFUSION_TASK, TIMESTEP])
``` 