### PR TITLE
Expose `t_type` arg in `FastModularTokenizer.get_token_id` and added a type assertion

### DIFF
--- a/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
@@ -1622,6 +1622,11 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
         Returns:
             :obj:`Optional[str]`: An optional token, :obj:`None` if out of vocabulary
         """
+        if not isinstance(id, int):
+            raise TypeError(
+                f"Expected 'id' to be an integer, got {type(id).__name__} instead."
+            )
+
         token_info = self.decoder_dict.get(id, None)
         if token_info is not None:
             return token_info["token"]

--- a/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
@@ -148,8 +148,8 @@ class FastModularTokenizer(OpBase):
 
         return (min_token, max_token)
 
-    def get_token_id(self, token_str: str) -> int:
-        ans = self._tokenizer.token_to_id(token_str)
+    def get_token_id(self, token_str: str, t_type: Optional[str] = None) -> int:
+        ans = self._tokenizer.token_to_id(token_str, t_type)
         assert ans is not None, f"could not find token id for token:{token_str}!"
         return ans
 

--- a/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
@@ -149,6 +149,16 @@ class FastModularTokenizer(OpBase):
         return (min_token, max_token)
 
     def get_token_id(self, token_str: str, t_type: Optional[str] = None) -> int:
+        """
+        Args:
+            token_str (:obj:`str`):
+                The token to convert
+            t_type (:obj:`str`): The sub-tokenizer to use. If None, the first (in order defined in the config)
+                sub-tokenizer is used. If the token is special, type should not be set.
+
+        Returns:
+            :obj:`int`: The token's id under the tokenizer type (if given)
+        """
         ans = self._tokenizer.token_to_id(token_str, t_type)
         assert ans is not None, f"could not find token id for token:{token_str}!"
         return ans


### PR DESCRIPTION
Minor changes.

Motivation:
1. While using a `FastModularTokenizer` instance, I need access to the tokens ids of the natural amino acids.
2. VSCode doesn't recognize `modulartokenizer` as module while importing it.
3. Type checking to avoid little & annoying bugs