### PR TITLE
Fix warning truncate tokens2

### DIFF
--- a/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
@@ -890,7 +890,7 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
             )
             if sub_max_len is not None:
                 if len(sub_encoding) > sub_max_len:
-                    overflow_info += f"{len(sub_encoding)} => {sub_max_len}|"
+                    overflow_info += f"{input_type}:{len(sub_encoding)}=>{sub_max_len}|"
                 sub_encoding.truncate(max_length=sub_max_len)
             encoded_list.append(sub_encoding)
             sequence_ids.extend([curr_sequence_id] * len(sub_encoding))
@@ -920,7 +920,7 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
 
         if max_len is not None:
             if len(merged_encoding) > max_len:
-                overflow_info += f"{len(merged_encoding)} => {max_len}|"
+                overflow_info += f"OVERALL:{len(merged_encoding)}=>{max_len}|"
             merged_encoding.truncate(max_length=max_len)
 
         if padding_token_id is None and padding_token is None:

--- a/fusedrug/data/tokenizer/modulartokenizer/test_multi_tokenizer_creation.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/test_multi_tokenizer_creation.py
@@ -36,11 +36,12 @@ def test_tokenizer(
     # Test general encoding: (per-tokenizer truncation works)
     t_inst = copy.deepcopy(t_inst)
 
-    enc = t_inst.encode_list(
+    enc, overflow_msg = t_inst.encode_list(
         typed_input_list=input_strings,
         max_len=cfg_raw["data"]["tokenizer"]["overall_max_len"],
+        return_overflow_info=True,
     )
-    print(f"encoded tokens: {enc.tokens}")
+    print(f"encoded tokens: {enc.tokens}, overflow=[{overflow_msg}]")
     # Test overall padding: (global padding works)
     enc_pad = t_inst.encode_list(
         typed_input_list=input_strings,

--- a/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/modular_tokenizer_ops.py
@@ -206,9 +206,14 @@ class FastModularTokenizer(OpBase):
                 )
 
         if isinstance(data, str):
-            encoded = self._tokenizer.encode(data, max_len=max_seq_len)
+            encoded, overflow_info = self._tokenizer.encode(
+                data, max_len=max_seq_len, return_overflow_info=True
+            )
         else:
-            encoded = self._tokenizer.encode_list(data, max_len=max_seq_len)
+            encoded, overflow_info = self._tokenizer.encode_list(
+                data, max_len=max_seq_len, return_overflow_info=True
+            )
+
         expected_max_len = self.get_max_len(override_max_len=max_seq_len)
         if (
             expected_max_len is not None
@@ -249,15 +254,8 @@ class FastModularTokenizer(OpBase):
         if (
             len(encoded.overflowing) > 0
         ):  # note, encoded.overflowing may have multiple items, and each item can contain multiple items
-            if isinstance(data, str):
-                overall_char_len = len(data)
-            else:
-                overall_char_len = sum([len(x.input_string) for x in data])
-
-            max_len = self.get_max_len(override_max_len=max_seq_len)
             print(
-                f"Warning: FastModularTokenizer (pid={os.getpid()}) had to truncate sequence. Original Sequence Length = {overall_char_len} \
-                    max supported = {max_len} {'possibly due to per-subtokenizer upper limits set in the input list' if max_len is None else ''} \
+                f"Warning: FastModularTokenizer (pid={os.getpid()}) had to truncate sequence: [{overflow_info}]  \
                     for tokenizer: {self._tokenizer_path} for sample_id {get_sample_id(sample_dict)}"
             )
 


### PR DESCRIPTION
A fix I did a long time ago for fixing the warning on truncation, showing the accuracy number based on number of token, and not string length