### PR TITLE
Added modular tokenizer files to the distribiotion via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers
+graft fusedrug/data/tokenizer/modulartokenizer/configs
+graft fusedrug/data/molecule/tokenizer/pretrained
+graft fusedrug/data/protein/tokenizer/pretrainedxshe  

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]
     ),
     license="Apache License 2.0",
+    include_package_data=True,
     install_requires=fusedrug_requirements,
     extras_require={
         "examples": fusedrug_examples_requirements,


### PR DESCRIPTION
Added a MANIFEST.in file with the pre-trained tokenizer files (tokenizer yaml and configs), so that when installing the package not from source the files will be available. 
TODO: add test for CI to verify that the needed file (at least the one for the regular and extended modular tokenizer) will be in place.  I did not locate a CI framework I could add to, so please clue me in so I could add this.