### PR TITLE
supporting overriding validate_ends_with_eos in tokenizer.call

### DIFF
--- a/fusedrug/data/tokenizer/modulartokenizer/configs/__init__.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/configs/__init__.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+# The directory containing this file
+CONFIG_DIRPATH = Path(__file__).parent
+
+
+def get_modular_tokenizer_config_dirpath() -> str:
+    return str(CONFIG_DIRPATH.resolve())
+

--- a/fusedrug/data/tokenizer/modulartokenizer/configs/__init__.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/configs/__init__.py
@@ -6,4 +6,3 @@ CONFIG_DIRPATH = Path(__file__).parent
 
 def get_modular_tokenizer_config_dirpath() -> str:
     return str(CONFIG_DIRPATH.resolve())
-

--- a/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/modular_tokenizer.py
@@ -776,6 +776,9 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
                 key="json_path",
                 val=config_out_path,
             )
+            tokenizer_dir = os.path.dirname(write_out_path)
+            if not os.path.exists(tokenizer_dir):
+                os.mkdir(tokenizer_dir)
             tokenizer_inst.save(write_out_path)
         tokenizer_config_overall = {
             "tokenizers_info": tokenizers_info_cfg,

--- a/fusedrug/data/tokenizer/ops/fast_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/fast_tokenizer_ops.py
@@ -22,7 +22,8 @@ class FastTokenizer(OpBase):
         max_size: int = None,
         pad_token: str = None,
         pad_type_id: str = None,
-        validate_ends_with_eos: Optional[str] = "<EOS>",
+        validate_ends_with_eos: Optional[bool] = True,
+        eos: Optional[str] = "<EOS>",
         verbose: bool = False,
         **kwargs: dict,
     ):
@@ -54,11 +55,12 @@ class FastTokenizer(OpBase):
             )
 
         self._validate_ends_with_eos = validate_ends_with_eos
+        self._eos = eos
 
-        if self._validate_ends_with_eos is not None:
-            if self._validate_ends_with_eos not in vocab.keys():
+        if self._validate_ends_with_eos:
+            if self._eos not in vocab.keys():
                 raise Exception(
-                    f"Could not find eos token = {validate_ends_with_eos} in {tokenizer_json}. You can disable the validation by setting validate_ends_with_eos=None"
+                    f"Could not find eos token = {self._eos} in {tokenizer_json}. You can disable the validation by setting validate_ends_with_eos=False"
                 )
 
         self._pad_id = pad_id
@@ -171,6 +173,7 @@ class FastTokenizer(OpBase):
         key_out_tokens_ids: str = None,
         key_out_attention_mask: str = None,
         convert_attention_mask_to_bool: bool = True,
+        validate_ends_with_eos: Optional[bool] = None,
     ) -> NDict:
         # if self._verbose:
         #     print(
@@ -182,11 +185,13 @@ class FastTokenizer(OpBase):
             raise Exception(
                 f"Expected key_in={key_in} to point to a string, and instead got a {type(data_str)}. value={data_str}"
             )
+        if validate_ends_with_eos is None:
+            validate_ends_with_eos = self._validate_ends_with_eos
 
-        if self._validate_ends_with_eos is not None:
-            if not data_str.rstrip().endswith(self._validate_ends_with_eos):
+        if validate_ends_with_eos:
+            if not data_str.rstrip().endswith(self._eos):
                 raise Exception(
-                    f"self._validate_ends_with_eos was set to {self._validate_ends_with_eos}, but about to encode a string that does not end with it. The str was: {data_str}"
+                    f"validate_ends_with_eos was set to {validate_ends_with_eos}, but about to encode a string that does not end with {self._eos}. The str was: {data_str}"
                 )
 
         encoded = self._tokenizer.encode(data_str)

--- a/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
@@ -1,9 +1,5 @@
-import unittest
-
 import hydra
-import os
 from omegaconf import DictConfig, OmegaConf
-from pathlib import Path
 
 
 from typing import Dict, Optional, Any
@@ -11,18 +7,6 @@ import pytorch_lightning as pl
 from fuse.utils import NDict
 from fusedrug.data.tokenizer.ops import FastModularTokenizer as FastTokenizer
 from fusedrug.data.tokenizer.modulartokenizer.modular_tokenizer import TypedInput
-from fusedrug.data.tokenizer.modulartokenizer.configs import get_modular_tokenizer_config_dirpath
-
-
-class TestModularTokenizerOps(unittest.TestCase):
-    def test_main(self) -> None:
-        config_path = os.path.relpath(
-            get_modular_tokenizer_config_dirpath(), Path(__file__).parent
-        )
-        with hydra.initialize(version_base=None, config_path=config_path):
-            cfg = hydra.compose(config_name="tokenizer_config")
-
-        main(cfg)
 
 
 def seed(seed_value: int) -> int:
@@ -180,4 +164,4 @@ def main(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
@@ -142,7 +142,7 @@ def main(cfg: DictConfig) -> None:
         tokenizer_path=cfg_raw["data"]["tokenizer"]["out_path"],
         max_size=global_max_len,
         pad_token="<PAD>",
-        validate_ends_with_eos="<EOS>",
+        validate_ends_with_eos=True,
     )
     test_tokenizer_op(
         tokenizer_op_inst=mod_tokenizer_op,
@@ -154,7 +154,7 @@ def main(cfg: DictConfig) -> None:
         tokenizer_path=cfg_raw["data"]["tokenizer"]["out_path"],
         max_size=global_max_len,
         pad_token="<PAD>",
-        validate_ends_with_eos="<EOS>",
+        validate_ends_with_eos=True,
     )
     test_tokenizer_op(
         tokenizer_op_inst=mod_tokenizer_op,

--- a/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
@@ -20,7 +20,7 @@ class TestModularTokenizerOps(unittest.TestCase):
             get_modular_tokenizer_config_dirpath(), Path(__file__).parent
         )
         with hydra.initialize(version_base=None, config_path=config_path):
-            cfg = hydra.compose(config_name="tokenizer_config_personal")
+            cfg = hydra.compose(config_name="tokenizer_config")
 
         main(cfg)
 

--- a/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
@@ -1,18 +1,28 @@
 import unittest
 
 import hydra
+import os
 from omegaconf import DictConfig, OmegaConf
+from pathlib import Path
+
 
 from typing import Dict, Optional, Any
 import pytorch_lightning as pl
 from fuse.utils import NDict
 from fusedrug.data.tokenizer.ops import FastModularTokenizer as FastTokenizer
 from fusedrug.data.tokenizer.modulartokenizer.modular_tokenizer import TypedInput
+from fusedrug.data.tokenizer.modulartokenizer.configs import get_modular_tokenizer_config_dirpath
 
 
 class TestModularTokenizerOps(unittest.TestCase):
     def test_main(self) -> None:
-        main()
+        config_path = os.path.relpath(
+            get_modular_tokenizer_config_dirpath(), Path(__file__).parent
+        )
+        with hydra.initialize(version_base=None, config_path=config_path):
+            cfg = hydra.compose(config_name="tokenizer_config_personal")
+
+        main(cfg)
 
 
 def seed(seed_value: int) -> int:

--- a/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
+++ b/fusedrug/data/tokenizer/ops/test_modular_tokenizer_ops.py
@@ -1,3 +1,5 @@
+import unittest
+
 import hydra
 from omegaconf import DictConfig, OmegaConf
 
@@ -6,6 +8,11 @@ import pytorch_lightning as pl
 from fuse.utils import NDict
 from fusedrug.data.tokenizer.ops import FastModularTokenizer as FastTokenizer
 from fusedrug.data.tokenizer.modulartokenizer.modular_tokenizer import TypedInput
+
+
+class TestModularTokenizerOps(unittest.TestCase):
+    def test_main(self) -> None:
+        main()
 
 
 def seed(seed_value: int) -> int:
@@ -163,4 +170,4 @@ def main(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    unittest.main()


### PR DESCRIPTION
The following changes were made to allow this:
1. In the init: change validate_ends_with_eos from str to bool, and add another argument eos, with default="<EOS>".  default behavior is maintained. I searched for all call for the init - None used validate_ends_with_eos
2. add a new boolean argument validate_ends_with_eos to tokenizer.call with default None. If not None - will override self._validate_ends_with_eos during the call.

The change was made to allow not adding <EOS> to the decoder, to allow it to be the same length as the label.  This allows cropping redundant padding in a batch - also in decoder input and label fields