### PR TITLE
Add gene symbol special token

### DIFF
--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/bpe_tokenizer_trained_on_chembl_zinc_with_aug_4272372_samples_balanced_1_1.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/bpe_tokenizer_trained_on_chembl_zinc_with_aug_4272372_samples_balanced_1_1.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3188,6 +3197,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "#": 527,
       "%": 528,
       "(": 529,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/cell_attributes_tokenizer.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/cell_attributes_tokenizer.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "[CL:0000499]": 3522,
       "[CL:2000060]": 3523,
       "[CL:0000235]": 3524,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/gene_tokenizer.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/gene_tokenizer.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "[100130093]": 5000,
       "[100133445]": 5001,
       "[100286793]": 5002,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/t5_tokenizer_AA_special.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_extended_modular_tokenizer/t5_tokenizer_AA_special.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "A": 501,
       "B": 502,
       "C": 503,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_modular_tokenizer/bpe_tokenizer_trained_on_chembl_zinc_with_aug_4272372_samples_balanced_1_1.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_modular_tokenizer/bpe_tokenizer_trained_on_chembl_zinc_with_aug_4272372_samples_balanced_1_1.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3188,6 +3197,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "#": 527,
       "%": 528,
       "(": 529,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_modular_tokenizer/cell_attributes_tokenizer.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_modular_tokenizer/cell_attributes_tokenizer.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "[CL:0000499]": 3522,
       "[CL:2000060]": 3523,
       "[CL:0000235]": 3524,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_modular_tokenizer/t5_tokenizer_AA_special.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/bmfm_modular_tokenizer/t5_tokenizer_AA_special.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "A": 501,
       "B": 502,
       "C": 503,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/modular_AA_SMILES_single_path/bpe_tokenizer_trained_on_chembl_zinc_with_aug_4272372_samples_balanced_1_1.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/modular_AA_SMILES_single_path/bpe_tokenizer_trained_on_chembl_zinc_with_aug_4272372_samples_balanced_1_1.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3188,6 +3197,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "#": 527,
       "%": 528,
       "(": 529,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/modular_AA_SMILES_single_path/cell_attributes_tokenizer.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/modular_AA_SMILES_single_path/cell_attributes_tokenizer.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "[CL:0000499]": 3522,
       "[CL:2000060]": 3523,
       "[CL:0000235]": 3524,

--- a/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/modular_AA_SMILES_single_path/t5_tokenizer_AA_special.json
+++ b/fusedrug/data/tokenizer/modulartokenizer/pretrained_tokenizers/modular_AA_SMILES_single_path/t5_tokenizer_AA_special.json
@@ -2855,6 +2855,15 @@
       "rstrip": false,
       "normalized": false,
       "special": true
+    },
+    {
+      "id": 317,
+      "content": "<GENE_SYMBOL>",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
     }
   ],
   "normalizer": null,
@@ -3193,6 +3202,7 @@
       "<BBBP>": 314,
       "<FDA_APPR>": 315,
       "<HIV_ACTIVITY>": 316,
+      "<GENE_SYMBOL>": 317,
       "A": 501,
       "B": 502,
       "C": 503,

--- a/fusedrug/data/tokenizer/modulartokenizer/special_tokens.py
+++ b/fusedrug/data/tokenizer/modulartokenizer/special_tokens.py
@@ -338,6 +338,7 @@ task_tokens = [  # pairwise tasks
     "AUTOENCODER_LATENT_LOG_VARIANCE",
     "AUTOENCODER_LATENT_MEAN",
     "AUTOENCODER_LATENT_SAMPLED_Z",
+    "GENE_SYMBOL",
 ]
 
 AA_tokens = [


### PR DESCRIPTION
Add special token for the new gene to AA sequence task. The new token needed is for the gene symbol given with each AA sequence. The goal of adding this task is so that the model learns the connection between genes and AA sequence information, and hopefully generate more meaningful representations. 
The task sequence will look like : 
`<GENE_SYMBOL>[GENE_NAME]<ALTERNATIVE><MOLECULAR_ENTITY><MOLECULAR_ENTITY_GENERAL_PROTEIN><SEQUENCE_NATURAL_START>ATGB[MASK]ATGA[MASK]ATGTGA<SEQUENCE_NATURAL_END>.`